### PR TITLE
Strip bank_id's last char

### DIFF
--- a/accounts/banks.py
+++ b/accounts/banks.py
@@ -33,7 +33,7 @@ def handle_recordbank_csv(csv_file):
     with transaction.atomic():
         for entry in csv.DictReader(StringIO("\r\n".join(csv_file.read().split("\n")[1:]) + "\r\n"), delimiter=";"):
             movement = Movement()
-            movement.bank_id = fr_or_nl(entry, "Ref. v/d verrichting")
+            movement.bank_id = fr_or_nl(entry, "Ref. v/d verrichting")[:-1]
             movement.date = datetime.strptime(fr_or_nl(entry, "Datum v. verrichting"), "%d-%m-%Y").date()
             movement.amount = float(fr_or_nl(entry, "Bedrag v/d verrichting").replace(".", "").replace(",", "."))
 

--- a/accounts/banks.py
+++ b/accounts/banks.py
@@ -32,7 +32,7 @@ def handle_recordbank_csv(csv_file):
 
     with transaction.atomic():
         for entry in csv.DictReader(StringIO("\r\n".join(csv_file.read().split("\n")[1:]) + "\r\n"), delimiter=";"):
-            bank_id = fr_or_nl(entry, "Ref. v/d verrichting")[:-1]
+            bank_id = fr_or_nl(entry, "Ref. v/d verrichting")[0:16]
             movement = Movement()
             movement.bank_id = bank_id
             movement.date = datetime.strptime(fr_or_nl(entry, "Datum v. verrichting"), "%d-%m-%Y").date()

--- a/accounts/banks.py
+++ b/accounts/banks.py
@@ -32,8 +32,9 @@ def handle_recordbank_csv(csv_file):
 
     with transaction.atomic():
         for entry in csv.DictReader(StringIO("\r\n".join(csv_file.read().split("\n")[1:]) + "\r\n"), delimiter=";"):
+            bank_id = fr_or_nl(entry, "Ref. v/d verrichting")[:-1]
             movement = Movement()
-            movement.bank_id = fr_or_nl(entry, "Ref. v/d verrichting")[:-1]
+            movement.bank_id = bank_id
             movement.date = datetime.strptime(fr_or_nl(entry, "Datum v. verrichting"), "%d-%m-%Y").date()
             movement.amount = float(fr_or_nl(entry, "Bedrag v/d verrichting").replace(".", "").replace(",", "."))
 
@@ -52,8 +53,8 @@ def handle_recordbank_csv(csv_file):
             movement.title = "FIXME"
 
             # I've already imported this movement, don't do anything
-            if Movement.objects.filter(bank_id=fr_or_nl(entry, "Ref. v/d verrichting")).exists():
-                movement = Movement.objects.get(bank_id=fr_or_nl(entry, "Ref. v/d verrichting"))
+            if Movement.objects.filter(bank_id=bank_id).exists():
+                movement = Movement.objects.get(bank_id=bank_id)
                 if movement.title == "FIXME":
                     title = guess_title(movement, entry)
                     if title:


### PR DESCRIPTION
CSV import create duplicate entries because it relies and the `bank_id`
field to always be the same for a transaction, across exports.

Observations show a transaction always has the same `bank_id` across
exports, **except** for the last char. I haven't found any documentation
about the CSV/bank_id format but looking a the duplicate entries we have
in the database and at entries from a couple of different CSV exports,
it should fix our issue.